### PR TITLE
Feat: CloudKit setting

### DIFF
--- a/SwiftUI/CoreDataDemo/CoreDataDemo.xcodeproj/project.pbxproj
+++ b/SwiftUI/CoreDataDemo/CoreDataDemo.xcodeproj/project.pbxproj
@@ -10,9 +10,22 @@
 		1A1A4C662D846CC500157DB4 /* CoreDataDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CoreDataDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		1A1EE0172D8F0327004206C9 /* Exceptions for "CoreDataDemo" folder in "CoreDataDemo" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 1A1A4C652D846CC500157DB4 /* CoreDataDemo */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		1A1A4C682D846CC500157DB4 /* CoreDataDemo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				1A1EE0172D8F0327004206C9 /* Exceptions for "CoreDataDemo" folder in "CoreDataDemo" target */,
+			);
 			path = CoreDataDemo;
 			sourceTree = "<group>";
 		};
@@ -249,12 +262,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = CoreDataDemo/CoreDataDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CoreDataDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = 2P5FNS3JAJ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CoreDataDemo/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -278,12 +293,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = CoreDataDemo/CoreDataDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CoreDataDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = 2P5FNS3JAJ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CoreDataDemo/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/SwiftUI/CoreDataDemo/CoreDataDemo/CoreDataDemo.entitlements
+++ b/SwiftUI/CoreDataDemo/CoreDataDemo/CoreDataDemo.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.seohyun.iOS.CoreDataDemo</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+</dict>
+</plist>

--- a/SwiftUI/CoreDataDemo/CoreDataDemo/Info.plist
+++ b/SwiftUI/CoreDataDemo/CoreDataDemo/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+</dict>
+</plist>

--- a/SwiftUI/CoreDataDemo/CoreDataDemo/Persistence.swift
+++ b/SwiftUI/CoreDataDemo/CoreDataDemo/Persistence.swift
@@ -11,15 +11,17 @@ struct PersistenceController {
     static let shared = PersistenceController()
 
 
-    let container: NSPersistentContainer
-
+    //let container: NSPersistentContainer
+    
+    let container: NSPersistentCloudKitContainer
+    
     init() {
-        container = NSPersistentContainer(name: "Products")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+        container = NSPersistentCloudKitContainer(name: "Products")
+        container.loadPersistentStores { (storeDescription, error) in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
-        })
-        //container.viewContext.automaticallyMergesChangesFromParent = true
+        }
+        container.viewContext.automaticallyMergesChangesFromParent = true
     }
 }


### PR DESCRIPTION
Setting CloudKit

- ProjectName > Target > Signing & Capabilities > + Capability 
- it should be added iCloud. 

By adding iCloud functionality, you can enable CloudKit services and remote notifications, allowing the app to store the database of a specific account in iCloud and configure its container. Additionally, monitoring is possible through the CloudKit Console.